### PR TITLE
Add Id to Payment (PHNX-8607)

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -626,6 +626,10 @@
       "Payment": {
         "type": "object",
         "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique id assigned by TextPay"
+          },
           "external_id": {
             "type": "string",
             "description": "The unique id assigned by the source system/database. If we detect a record with the same external_id, it will be updated, otherwise it will be added."


### PR DESCRIPTION
Motivation
---
 - We need to add the Text Pay id to the payment object

Modification
---
 - Added the internal id property

https://centeredge.atlassian.net/browse/PHNX-8607
