### PR TITLE
Add last_4 field to payment (PHNX-8666)

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -643,6 +643,11 @@
             "description": "The secure friendly display name of the payment method",
             "example": "VISA **** 3421"
           },
+          "last_4": {
+            "type": "string",
+            "description": "The last 4 digits of the payment method.",
+            "example": "3421"
+          },
           "amount": {
             "type": "number",
             "description": "#####.## The amount that was paid."


### PR DESCRIPTION
Motivation
------

Hyfin has added a last_4 field to the payment information, so that we do not need to parse the last 4 digits of a card out of the display name.

Modifications
-------

Added last_4 field to payment

https://centeredge.atlassian.net/browse/PHNX-8666
