### PR TITLE
Fix error response schema (PHNX-8687)

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -1105,15 +1105,18 @@
         }
       },
       "ErrorResponse": {
-        "success": {
-          "type": "boolean",
-          "description": "A flag that signals if the request was successful"
-        },
-        "errors": {
-          "type": "array",
-          "description": "A list of errors returned from the endpoint",
-          "items": {
-            "type": "string"
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "A flag that signals if the request was successful"
+          },
+          "errors": {
+            "type": "array",
+            "description": "A list of errors returned from the endpoint",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }


### PR DESCRIPTION
Motivation
-------

The error response schema is missing the "type" and "properties" keys.

Modifications
------------

Added missing keys to error response schema

https://centeredge.atlassian.net/browse/PHNX-8687
