### PR TITLE
Add Auth Code Field to Payment Schema (PHNX-8853)

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -859,6 +859,11 @@
             "description": "The last 4 digits of the payment method.",
             "example": "3421"
           },
+          "auth_code": {
+            "type": "string",
+            "description": "The authorization code for the payment",
+            "example": "93896G"
+          },
           "amount": {
             "type": "number",
             "description": "#####.## The amount that was paid."


### PR DESCRIPTION
Motivation
------------

Hyfin returns an "auth_code" field for a payment, but the swagger spec does not include that field.

Modifications
------------

Add auth code field to payment schema.