### PR TITLE
Use new tipping options (ADV-19592)

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -583,6 +583,7 @@
         "properties": {
           "tipping_enabled": {
             "type": "boolean",
+            "default": true,
             "description": "Enable or disables the popup window that requests gratuity"
           }
         },        
@@ -992,6 +993,10 @@
               { "$ref": "#/components/schemas/ExternalId" },
               { "$ref": "#/components/schemas/Customer" }
             ]
+          },
+          "tippingOptions": {
+            "description": "A set of options for tipping on invoices",
+            "allOf": [{ "$ref": "#/components/schemas/TippingOptions" }]
           },
           "lines": {
             "description": "A list of line items on the invoice. This field is only required if description is not passed in.",


### PR DESCRIPTION
Motivation
----
The new tipping options object should be used on the add update invoice

Modifications
----
* Added new property to AddUpdateInvoiceRequest to use new property

Result
----
tipping options are available on the request from the client sdk

https://centeredge.atlassian.net/browse/ADV-19592
