### PR TITLE
Fix typo in Option name in AddUpdateInvoiceRequest (ADV-19595)

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -583,7 +583,7 @@
         "properties": {
           "tippingEnabled": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "description": "Enable or disables the popup window that requests gratuity"
           }
         },  

--- a/swagger.json
+++ b/swagger.json
@@ -581,13 +581,13 @@
       "TippingOptions": {
         "type": "object",
         "properties": {
-          "tippingEnabled": {
+          "tipping_enabled": {
             "type": "boolean",
             "default": false,
             "description": "Enable or disables the popup window that requests gratuity"
           }
         },  
-        "required": ["tippingEnabled"]
+        "required": ["tipping_enabled"]
       },
       "ExternalId": {
         "type": "object",

--- a/swagger.json
+++ b/swagger.json
@@ -586,7 +586,7 @@
             "default": true,
             "description": "Enable or disables the popup window that requests gratuity"
           }
-        },        
+        },  
         "required": ["tippingEnabled"]
       },
       "ExternalId": {

--- a/swagger.json
+++ b/swagger.json
@@ -581,13 +581,13 @@
       "TippingOptions": {
         "type": "object",
         "properties": {
-          "tipping_enabled": {
+          "tippingEnabled": {
             "type": "boolean",
             "default": true,
             "description": "Enable or disables the popup window that requests gratuity"
           }
         },        
-        "required": ["tipping_enabled"]
+        "required": ["tippingEnabled"]
       },
       "ExternalId": {
         "type": "object",
@@ -994,7 +994,7 @@
               { "$ref": "#/components/schemas/Customer" }
             ]
           },
-          "tippingOptions": {
+          "options": {
             "description": "A set of options for tipping on invoices",
             "allOf": [{ "$ref": "#/components/schemas/TippingOptions" }]
           },

--- a/swagger.json
+++ b/swagger.json
@@ -993,7 +993,7 @@
               { "$ref": "#/components/schemas/ExternalId" },
               { "$ref": "#/components/schemas/Customer" }
             ]
-          },
+          }, 
           "options": {
             "description": "A set of options for tipping on invoices",
             "allOf": [{ "$ref": "#/components/schemas/TippingOptions" }]


### PR DESCRIPTION
Motivation
----
Typo in naming of object is causing the request to send as expected

Modifications
----
* AddUpdateInvoiceRequest tipping option property renamed to fix typo

Result
----
Hyfin should now get the expected property

https://centeredge.atlassian.net/browse/ADV-19595
