### PR TITLE
Add Payment Token Data To Payment (ADV-20075)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           dotnet-version: 6.0.x
       - name: Install Yardarm
-        run: dotnet tool install --global --version 0.2.0-alpha004 Yardarm.CommandLine
+        run: dotnet tool install --global --version 0.3.0-beta0001 Yardarm.CommandLine
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.11
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         run: sed -i 's/0.0.0-replace/${{ steps.gitversion.outputs.legacySemVerPadded }}/g' swagger.json
 
       - name: Build
-        run: yardarm generate -i ./swagger.json --nupkg ./dist/ -n CenterEdge.TextPay.Api -v ${{ steps.gitversion.outputs.nuGetVersionV2 }} -x Yardarm.SystemTextJson Yardarm.Microsoft.Extensions.Http --repository-url https://github.com/${GITHUB_REPOSITORY}.git --repository-commit ${GITHUB_SHA} --embed -f netstandard2.0 net6.0
+        run: yardarm generate -i ./swagger.json --nupkg ./dist/ -n CenterEdge.TextPay.Api -v ${{ steps.gitversion.outputs.nuGetVersionV2 }} -x Yardarm.SystemTextJson Yardarm.MicrosoftExtensionsHttp --repository-url https://github.com/${GITHUB_REPOSITORY}.git --repository-commit ${GITHUB_SHA} --embed -f netstandard2.0 net6.0
 
       - name: Push
         working-directory: ./dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         run: sed -i 's/0.0.0-replace/${{ steps.gitversion.outputs.legacySemVerPadded }}/g' swagger.json
 
       - name: Build
-        run: yardarm generate -i ./swagger.json --nupkg ./dist/ -n CenterEdge.TextPay.Api -v ${{ steps.gitversion.outputs.nuGetVersionV2  }} -x Yardarm.SystemTextJson --repository-url https://github.com/${GITHUB_REPOSITORY}.git --repository-commit ${GITHUB_SHA} -f netstandard2.0 net6.0
+        run: yardarm generate -i ./swagger.json --nupkg ./dist/ -n CenterEdge.TextPay.Api -v ${{ steps.gitversion.outputs.nuGetVersionV2 }} -x Yardarm.SystemTextJson Yardarm.Microsoft.Extensions.Http --repository-url https://github.com/${GITHUB_REPOSITORY}.git --repository-commit ${GITHUB_SHA} --embed -f netstandard2.0 net6.0
 
       - name: Push
         working-directory: ./dist

--- a/swagger.json
+++ b/swagger.json
@@ -921,6 +921,11 @@
             "type": "boolean",
             "description": "This flag represents whether the payment record is active.",
             "default": true
+          },
+          "payment_token": {
+            "type": "string",
+            "description": "The tokenized form of the Card payment that was received at the time payment was collected.",
+            "example": "DC4:ABCD1234"
           }
         },
         "required": [


### PR DESCRIPTION
Motivation
----
We need to include the property for the payment token that hyfin is returning to us so that we can use it in advantage or other locations

Modifications
----
* Included new `payment_token` property on the payment object schema so it is available for SDK generation
* Upgraded yardarm to 0.3.0-beta0001

Result
----
payment_token property will show up in the SDK

https://centeredge.atlassian.net/browse/ADV-20075
