### PR TITLE
Add "cash_tax" to invoice total request (PHNX-13678)

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -949,13 +949,19 @@
           "tax": {
             "type": "number",
             "format": "decimal",
-            "description": "The tax amount on the invoice",
+            "description": "The tax amount on the invoice when payment card price.",
             "default": 0
           },
           "total": {
             "type": "number",
             "format": "decimal",
-            "description": "The total amount of the invoice (including tax)."
+            "description": "The credit card price of the invoice (including tax)."
+          },
+          "cash_tax": {
+            "type": "number",
+            "format": "decimal",
+            "description": "The tax amount on the invoice when paying the cash price.",
+            "nullable": true
           },
           "cash_total": {
             "type": "number",


### PR DESCRIPTION
Motivation
----------
Hyfin has added this to the API so we can show the difference in tax for cash payments.

Modifications
-------------
Add the attribute and update descriptions.

https://centeredge.atlassian.net/browse/PHNX-13678
