### PR TITLE
Fix Typo on GET Invoices Response (PHNX-17807)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Note: TextPay (a.k.a. DashNow) is now known as Hyfin.
 
-OpenAPI 3.0 spec based on [Hyfin documentation](https://centeredge.hyfin.app/docs/2.0c/introduction).
+OpenAPI 3.0 spec based on [Hyfin documentation](https://centeredge.hyfin.app/docs/2.0c/introduction). 

--- a/swagger.json
+++ b/swagger.json
@@ -1388,7 +1388,7 @@
           },
           "records": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Invoice"},
+            "items": { "$ref": "#/components/schemas/GetInvoiceResponse"},
             "description": "Invoices returned by the query up to 1,000 records."
           }
         }


### PR DESCRIPTION
Motivations
-------------

The swagger spec for the GET invoices response looks for the "Invoice" schema instead of the "GetInvoiceResponse" schema.

Modifications
-------------

Fix typo.

https://centeredge.atlassian.net/browse/PHNX-17807
